### PR TITLE
fix: make asteroid explosion play while colliding with enemies

### DIFF
--- a/Assets/Scripts/Gameplay/Asteroid.cs
+++ b/Assets/Scripts/Gameplay/Asteroid.cs
@@ -97,6 +97,7 @@ public class Asteroid : MonoBehaviour
 
         // Fetch an explosion object from the object pool
         GameObject pooledExplosion = ObjectPooler.Instance.SpawnFromPool("Explosion", transform.position, Quaternion.identity);
+        AudioManager.Instance.PlayClip(explodeClip);
 
         // if (pooledExplosion)
         // {


### PR DESCRIPTION
The asteroids' explosion audio was only playing while colliding, it was not triggering while triggered by some other object. That's fixed.

Fixes #46